### PR TITLE
[web] Fix number of rendered hooks in `useSWRs`

### DIFF
--- a/packages/bento-web/src/dashboard/utils/useWalletBalances.ts
+++ b/packages/bento-web/src/dashboard/utils/useWalletBalances.ts
@@ -42,7 +42,7 @@ const useSWRs = <T extends any>(
   requests: Requests,
   hook: typeof useAxiosSWR,
 ) => {
-  const keys = Object.keys(requests) as (keyof typeof KEYS_BY_NETWORK)[];
+  const keys = Object.keys(KEYS_BY_NETWORK) as (keyof typeof KEYS_BY_NETWORK)[];
   const res: SWRResponse<T, any>[] = [];
   for (const key of keys) {
     const req = requests[key];


### PR DESCRIPTION
## Background
- Closes #89 
- The number of rendered hooks was dynamic(based on `requests`) and was causing error(`Error: Rendered more hooks than during the previous render`)