### PR TITLE
[web] Fix typo in redirect rule: `/profile/intro` -> `/profile/landing`

### DIFF
--- a/packages/bento-web/next.config.js
+++ b/packages/bento-web/next.config.js
@@ -36,7 +36,7 @@ module.exports = withPlugins(
     async redirects() {
       return [
         {
-          source: '/profile/intro',
+          source: '/profile/landing',
           destination: '/profile/intro',
           permanent: false,
         },


### PR DESCRIPTION
Occurred after #196 