### PR TITLE
[web] Fix typo in default profile information

### DIFF
--- a/packages/bento-web/src/dashboard/sections/ProfileSummarySection.tsx
+++ b/packages/bento-web/src/dashboard/sections/ProfileSummarySection.tsx
@@ -118,7 +118,7 @@ export const ProfileSummarySection: React.FC = () => {
             <Information>
               {!profile?.username ? (
                 <>
-                  <EmptyText>Upda!profile?.usernamete your Profile</EmptyText>
+                  <EmptyText>Update your Profile</EmptyText>
                   <Username>{`@unknown`}</Username>
                 </>
               ) : (


### PR DESCRIPTION
<img width="370" alt="스크린샷 2022-09-28 오후 9 45 27" src="https://user-images.githubusercontent.com/32605822/192781818-a911c2a8-d2b1-45fb-9cdb-1e373e56f11b.png">
