### PR TITLE
[web] Move stylesheets to `_document`

### DIFF
--- a/packages/bento-web/pages/_app.tsx
+++ b/packages/bento-web/pages/_app.tsx
@@ -11,7 +11,6 @@ import '@/styles/tailwind.css';
 import '@/styles/fonts.css';
 
 import { AppProps } from 'next/app';
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 import styled from 'styled-components';
 
@@ -62,19 +61,6 @@ const App = ({ Component, pageProps }: AppProps) => {
 
   return (
     <React.Fragment>
-      <Head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="anonymous"
-        />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;500;600;700;800;900&display=swap"
-          rel="stylesheet"
-        />
-      </Head>
-
       <GlobalStyle />
       <ToastProvider />
 

--- a/packages/bento-web/pages/_document.tsx
+++ b/packages/bento-web/pages/_document.tsx
@@ -61,6 +61,17 @@ export default class MyDocument extends Document {
             href="/favicon-16x16.png"
           />
           <link rel="manifest" href="/site.webmanifest" />
+
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link
+            rel="preconnect"
+            href="https://fonts.gstatic.com"
+            crossOrigin="anonymous"
+          />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;500;600;700;800;900&display=swap"
+            rel="stylesheet"
+          />
         </Head>
 
         {/* NOTE: preload 클래스 삭제 전에는 CSS 트랜지션 비활성화 */}


### PR DESCRIPTION
## Background
```
Do not add stylesheets using next/head (see <link rel="stylesheet"> tag with href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;500;600;700;800;900&display=swap"). Use Document instead. 
See more info here: https://nextjs.org/docs/messages/no-stylesheets-in-head-component
```