### PR TITLE
[web] Remove CORS middleware from `/api/auth`

### DIFF
--- a/packages/bento-web/pages/api/auth/index.ts
+++ b/packages/bento-web/pages/api/auth/index.ts
@@ -1,7 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
-import { withCORS } from '@/utils/middlewares/withCORS';
-
 import { Supabase } from '@/utils';
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
@@ -15,4 +13,4 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 };
 
-export default withCORS(handler);
+export default handler;


### PR DESCRIPTION
## Background
```
[POST] /api/auth
13:50:45:40
2022-10-03T04:50:45.498Z	dfe5c517-29e1-4a83-b9fc-98d1d32d04b7	ERROR	Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at new NodeError (node:internal/errors:372:5)
    at ServerResponse.setHeader (node:_http_outgoing:576:11)
    at Object.sendEtagResponse (/var/task/node_modules/next/dist/server/send-payload/index.js:29:13)
    at sendData (/var/task/node_modules/next/dist/server/api-utils/node.js:172:27)
    at ServerResponse.apiRes.send (/var/task/node_modules/next/dist/server/api-utils/node.js:349:31)
    at handler (/var/task/packages/bento-web/.next/server/pages/api/auth.js:50:25)
    at /var/task/packages/bento-web/.next/server/chunks/529.js:28:22
    at Object.apiResolver (/var/task/node_modules/next/dist/server/api-utils/node.js:366:15)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async NextNodeServer.runApi (/var/task/node_modules/next/dist/server/next-server.js:481:9) {
  code: 'ERR_HTTP_HEADERS_SENT'
}
```