### PR TITLE
[web/safari] Remove `aspect-ratio` attribute in `ProfileSummarySection` to add support for Safari

### DIFF
--- a/packages/bento-web/src/dashboard/DashboardMain.tsx
+++ b/packages/bento-web/src/dashboard/DashboardMain.tsx
@@ -241,7 +241,6 @@ const ProfileContainer = styled.div`
 
     & div.profile-summary {
       height: 360px;
-      aspect-ratio: unset;
       padding-bottom: unset;
     }
   }

--- a/packages/bento-web/src/dashboard/sections/ProfileSummarySection.tsx
+++ b/packages/bento-web/src/dashboard/sections/ProfileSummarySection.tsx
@@ -190,7 +190,6 @@ const Wrapper = styled.div`
 
 const BorderWrapper = styled.div`
   width: 100%;
-  aspect-ratio: 1;
   padding-bottom: 100%;
 
   position: relative;


### PR DESCRIPTION
## Background

<img width="345" alt="image" src="https://user-images.githubusercontent.com/32605822/193505869-2f89a9f0-537d-4032-bc44-30fed6d12a23.png">
