### PR TITLE
[web] Add missing top margin of dashboard's `Assets` section

### DIFF
--- a/packages/bento-web/src/dashboard/DashboardMain.tsx
+++ b/packages/bento-web/src/dashboard/DashboardMain.tsx
@@ -162,7 +162,10 @@ export const DashboardMain: React.FC<DashboardMainProps> = ({
             items={DASHBOARD_TAB_ITEMS}
           />
           <DashboardContent>
-            <AnimatedTab selected={currentTab === DashboardTabType.Crypto}>
+            <AnimatedTab
+              className="tab-crypto"
+              selected={currentTab === DashboardTabType.Crypto}
+            >
               <TopSummaryContainer>
                 <AssetRatioSection
                   netWorthInUSD={netWorthInUSD}
@@ -341,7 +344,6 @@ const DashboardContent = styled.div`
   padding: 27px 33px;
   display: flex;
   flex-direction: column;
-  gap: 32px;
   flex: 1;
 
   background: ${Colors.black};
@@ -351,6 +353,10 @@ const DashboardContent = styled.div`
   @media (max-width: 1240px) {
     padding: 24px 0 0;
     border: 0;
+  }
+
+  & .tab-crypto {
+    gap: 32px;
   }
 `;
 const TopSummaryContainer = styled.div`


### PR DESCRIPTION
## Background
- https://inevitablechanges.slack.com/archives/C045BNB6JSE/p1665207044849819

## Screenshots
<img width="448" alt="image" src="https://user-images.githubusercontent.com/32605822/194771871-405efc9c-47f7-4189-bf1e-121883ff6380.png">
