### PR TITLE
[web] Use `reduce` in `safePromiseAll` to make it work for 2D arrays

### DIFF
--- a/packages/bento-common/utils/safer-promises.ts
+++ b/packages/bento-common/utils/safer-promises.ts
@@ -1,6 +1,7 @@
 export const safePromiseAll = async <T extends any>(promises: Promise<T>[]) =>
-  (await Promise.allSettled(promises)).flatMap((res) =>
-    res.status === 'fulfilled' ? res.value : [],
+  (await Promise.allSettled(promises)).reduce(
+    (acc, res) => (res.status === 'fulfilled' ? [...acc, res.value] : acc),
+    [] as T[],
   );
 
 export const safeAsyncFlatMap = async <T extends any, U extends any>(


### PR DESCRIPTION
```tsx
const oldSafePromiseAll = async <T extends any>(promises: Promise<T>[]) =>
  (await Promise.allSettled(promises)).flatMap((res) =>
    res.status === 'fulfilled' ? res.value : [],
  );

const safePromiseAll = async <T extends any>(promises: Promise<T>[]) =>
  (await Promise.allSettled(promises)).reduce(
    (acc, res) => (res.status === 'fulfilled' ? [...acc, res.value] : acc),
    [] as T[],
  );

const items = [1, 2, 3]

// invalid
oldSafePromiseAll(items.map(async (v, i) => [v, i])).then(console.log)
// [1, 0, 2, 1, 3, 2]

// valid
safePromiseAll(items.map(async (v, i) => [v, i])).then(console.log)
// [[1, 0], [2, 1], [3, 2]]
```

- [TypeScript Playground](https://www.typescriptlang.org/play?target=9&ts=4.8.4#code/MYewdgzgLgBCA2ATAygQwGYFMAKAnEAtgJYSYCC88MAvDKhAJ5jAwA8AKjJgB5SZiIIdMAwB8ACgAO+YqQgAuGHkIlMHUQG0AugEoaogFAwY41AHdURWMtmYAdKkrJMUKPEyIpM1RB0676PCoUACyqJLi4riYvvpGxjDREHbQwQCuQtRZMADk6Gnw6ESUHjkwAPyJMXYAbo5pmDCK2gA08ToA3AYGoJCwEBg43qQUVLT0TCwcXLz8gsJiXipyijaq6tp61IbGphZWSsP2jvDOru6e0ssxfnbRiGnAmOLxu6jAwC1VsdsmSSlQdKZbJ5ApFEqIMqVDR2WHvT7fWr1TBaJp0D46NoJGDaOhCditdpdHrgaAwKyYAiZHEARi+ACYvgBmLTdAD0bPJYDq8CIiAMCBQgzWI0o4gpVLsBHCpkYzBMNS+RC2ohxivJun8UAAFvxxL0IAh7PAQABzHQGDm0r4ABgZXzpMCZDNZls5PL5BgGWBF5DFEuS0oiE3l4nVyv0aqVmrsOr1BqNdhN5rdOI0jptWi+GkZMBpWZxzpg9K0rKAA)