### PR TITLE
[web] Show each net worth as tooltip in `assetRatioByPlatform`

### DIFF
--- a/packages/bento-web/src/dashboard/sections/AssetRatioSection/AssetRatioSection.tsx
+++ b/packages/bento-web/src/dashboard/sections/AssetRatioSection/AssetRatioSection.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from 'next-i18next';
 import { useMemo } from 'react';
 import styled from 'styled-components';
 
+import { AnimatedToolTip } from '@/components/system';
+
 import { displayName } from '@/dashboard/constants/platform';
 import { DashboardTokenBalance } from '@/dashboard/types/TokenBalance';
 import { Colors, systemFontStack } from '@/styles';
@@ -52,14 +54,21 @@ export const AssetRatioSection: React.FC<AssetRatioSectionProps> = ({
 
       <BadgeList>
         {assetRatioByPlatform.map((item) => (
-          <Badge key={item.platform}>
-            <img src={`/assets/icons/${item.platform}.png`} alt={item.name} />
-            <span>
-              {`${item.ratio.toLocaleString(undefined, {
-                maximumFractionDigits: 2,
-              })}%`}
-            </span>
-          </Badge>
+          <AnimatedToolTip
+            key={item.platform}
+            label={`$${item.netWorth.toLocaleString(undefined, {
+              maximumFractionDigits: 2,
+            })}`}
+          >
+            <Badge style={{ cursor: 'pointer' }}>
+              <img src={`/assets/icons/${item.platform}.png`} alt={item.name} />
+              <span>
+                {`${item.ratio.toLocaleString(undefined, {
+                  maximumFractionDigits: 2,
+                })}%`}
+              </span>
+            </Badge>
+          </AnimatedToolTip>
         ))}
       </BadgeList>
     </Container>


### PR DESCRIPTION
<img width="234" alt="Screen Shot 2022-10-14 at 2 07 34 PM" src="https://user-images.githubusercontent.com/32605822/195766703-aa790309-c9fc-431d-b3bb-d1e9bfcdc114.png">
