### PR TITLE
[web] Show Osmosis Pool IDs without shortening

### DIFF
--- a/packages/bento-web/src/dashboard/components/DeFiStakingItem.tsx
+++ b/packages/bento-web/src/dashboard/components/DeFiStakingItem.tsx
@@ -74,7 +74,11 @@ export const DeFiStakingItem: React.FC<DeFiStakingItemProps> = ({
                 : t('Rep Contract')}
             </span>
             <span className="sys">
-              <InlineBadge>{shortenAddress(protocol.address)}</InlineBadge>
+              <InlineBadge>
+                {protocol.type === OsmosisDeFiType.OSMOSIS_GAMM_LP
+                  ? protocol.address
+                  : shortenAddress(protocol.address)}
+              </InlineBadge>
             </span>
           </AccountItem>
         )}


### PR DESCRIPTION
<img width="517" alt="Screen Shot 2022-10-18 at 8 05 29 AM" src="https://user-images.githubusercontent.com/32605822/196299712-0bb7b746-32e3-4eb0-8cc7-4a067e1673fd.png">

Fixing `816...816` to `816`