### PR TITLE
[api] Set `rewards` to `null` for Osmosis GAMM LPs

### DIFF
--- a/packages/bento-api/src/defi/osmosis/osmosis/gamm.ts
+++ b/packages/bento-api/src/defi/osmosis/osmosis/gamm.ts
@@ -325,7 +325,7 @@ export const getGAMMLPs = async (
         tokens: tokens,
         wallet: fromAmount(walletAmount),
         staked: fromAmount(stakedAmount),
-        rewards: 'unavailable',
+        rewards: null,
         unstake: {
           claimable: fromAmount(claimableAmount),
           pending: fromAmount(pendingAmount),


### PR DESCRIPTION
They just go directly to your wallet so it's `null`.